### PR TITLE
Customize add/run tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,9 @@ modules.order
 Module.symvers
 Mkfile.old
 dkms.conf
+
+# Vim swap and undo files, build dir
+*~
+*sw?
+.gitignore
+/build

--- a/.gitignore
+++ b/.gitignore
@@ -54,5 +54,4 @@ dkms.conf
 # Vim swap and undo files, build dir
 *~
 *sw?
-.gitignore
 /build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,29 @@
 # Tell cmake the featureset we require
 cmake_minimum_required(VERSION 3.15)
+
 # Project name and version with languages/compilers required
 project(Firefly VERSION 1.0 LANGUAGES CXX)
-# Configure building the gmsh mesh reader
-# add_library(GmshMeshReader GmshMeshReader.cpp GmshMeshReader.hpp)
+
+# Set cmake modules directory
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+
 # Configure building the main executable
 add_executable(firefly firefly.cpp)
-# Configure the link command
-# target_link_libraries(firefly PRIVATE GmshMeshReader)
+
 # Configure cmake's testing system
 enable_testing()
-# Add a test, running the chillax executable, non-zero exit code will fail the test
-add_test(NAME firefly COMMAND firefly)
+
+# Include function used to add regression tests
+include(add_regression_test)
+
+# Set paths required for running tests
+set(TEST_RUNNER ${CMAKE_SOURCE_DIR}/cmake/test_runner.cmake)
+
+# Add tests
+add_regression_test(test_example_pass_regexp firefly
+                    EXTRA_PASS_REGEXP "Firefly Project"
+                    LABELS "basic")
+add_regression_test(test_example_fail_regexp firefly
+                    EXTRA_FAIL_REGEXP "Firefly Project"
+                    EXTRA_PROPERTIES "WILL_FAIL;1"
+                    LABELS "basic")

--- a/cmake/add_regression_test.cmake
+++ b/cmake/add_regression_test.cmake
@@ -1,0 +1,115 @@
+################################################################################
+#
+# \file      add_regression_test.cmake
+# \brief     Function used to add a regression test to the ctest test suite
+#
+################################################################################
+
+# ##############################################################################
+# Function used to add a regression test to the ctest test suite
+# add_regression_test( <test_name> <executable>
+#                      [INPUTFILES file1 file2 ...]
+#                      [ARGS arg1 arg2 ...]
+#                      [LABELS label1 label2 ...]
+#                      [EXTRA_PASS_REGEXP extra_pass_regexp]
+#                      [EXTRA_FAIL_REGEXP extra_fail_regexp]
+#                      [EXTRA_PROPERTIES extra_properties]
+#
+# Mandatory arguments:
+# --------------------
+#
+# <test_name> - Name of the test.
+# <executable> - Name of the executable to test.
+#
+# Optional arguments:
+# -------------------
+#
+# INPUTFILES file1 file2 ... - Input files required for the test. This list of
+# files includes files needed for running the test, e.g., control file
+# (containing user input), mesh file, etc., as well as file required for
+# evaluating the test, e.g., diff program configuration file. All input files
+# are soft-linked from the source dir to the build dir. Default: "".
+#
+# ARGS arg1 arg2 ... - Arguments to pass to executable tested. Default: "".
+#
+# LABELS label1 label2 ... - Optional labels associated with the test.
+# Default: "${executable}".
+#
+# EXTRA_PASS_REGEXP extra_pass_regexp - Extra pass regular expression
+#
+# EXTRA_FAIL_REGEXP extra_fail_regexp - Extra fail regular expression
+#
+# EXTRA_PROPERTIES extra_properties - Extra test properties to pass to add_test
+#
+# ##############################################################################
+function(ADD_REGRESSION_TEST test_name executable)
+
+  set(oneValueArgs EXTRA_PASS_REGEXP EXTRA_FAIL_REGEXP)
+  set(multiValueArgs INPUTFILES ARGS EXTRA_PROPERTIES)
+  cmake_parse_arguments(ARG "${options}" "${oneValueArgs}" "${multiValueArgs}"
+                        ${ARGN})
+
+  # Will collect test properties
+  set(test_properties)
+
+  list(APPEND test_properties ${ARG_EXTRA_PROPERTIES})
+  #message("prop: ${test_properties}")
+
+  # Set and create test run directory
+  set(workdir ${CMAKE_CURRENT_BINARY_DIR}/${test_name})
+  file(MAKE_DIRECTORY ${workdir})
+
+  # Add labels to test
+  if (ARG_LABELS)
+    list(APPEND TEST_LABELS ${ARG_LABELS})
+  endif()
+  # prepare test labels to pass as cmake script arguments
+  set(ARG_LABELS ${TEST_LABELS})
+  string(REPLACE ";" " " ARG_LABELS "${ARG_LABELS}")
+
+  # Construct and echo configuration for test being added
+  set(msg "Add regression test ${test_name} for ${executable}")
+
+  if (ARG_ARGS)
+    string(REPLACE ";" " " ARGUMENTS "${ARG_ARGS}")
+    string(CONCAT msg "${msg}, args: '${ARGUMENTS}'")
+  endif()
+
+  set(EXECUTABLE "${CMAKE_BINARY_DIR}/${executable}")
+
+  # Add the test. See test_runner.cmake for documentation of the arguments.
+  add_test(NAME ${test_name}
+           COMMAND ${CMAKE_COMMAND}
+           -DTEST_NAME=${test_name}
+           -DWORKDIR=${workdir}
+           -DTEST_EXECUTABLE=${EXECUTABLE}
+           -DTEST_EXECUTABLE_ARGS=${ARGUMENTS}
+           -DTEST_LABELS=${ARG_LABELS}
+           -P ${TEST_RUNNER}
+           WORKING_DIRECTORY ${workdir})
+
+  # build pass regular expression list for test
+  set(pass_regexp "")
+  # add extra pass regexp
+  list(APPEND pass_regexp "${ARG_EXTRA_PASS_REGEXP}")
+
+  # build fail regular expression list for test
+  set(fail_regexp "")
+  # add extra fail regexp
+  list(APPEND fail_regexp "${ARG_EXTRA_FAIL_REGEXP}")
+
+  #message("'${test_name}' pass regexp: ${pass_regexp}, fail regexp: ${fail_regexp}")
+
+  # Set test properties and instruct ctest to check textual diff output against
+  # the regular expressions specified.
+  set_tests_properties(${test_name} PROPERTIES ${test_properties}
+                       PASS_REGULAR_EXPRESSION "${pass_regexp}"
+                       FAIL_REGULAR_EXPRESSION "${fail_regexp}")
+
+  # Set labels cmake test property. The LABELS built-in cmake property is not
+  # passed as part of test_properties above in set_test_properties as
+  # TEST_LABELS is a cmake list and passing in lists of lists does not work as
+  # expected.
+  set_property(TEST ${test_name} PROPERTY LABELS ${TEST_LABELS})
+
+endfunction()

--- a/cmake/test_runner.cmake
+++ b/cmake/test_runner.cmake
@@ -1,0 +1,39 @@
+################################################################################
+#
+# \file      test_runner.cmake
+# \brief     Regression test runner using the cmake scripting language
+#
+################################################################################
+
+# Covert string to list of test labels
+string(REPLACE " " ";" TEST_LABELS "${TEST_LABELS}")
+# Covert string to list of test executable arguments
+string(REPLACE " " ";" TEST_EXECUTABLE_ARGS "${TEST_EXECUTABLE_ARGS}")
+
+# Print test runner configuration
+message("Test runner configuration:")
+message("  TEST_NAME (name of test)                                    : ${TEST_NAME}")
+message("  WORKDIR (test run directory)                                : ${WORKDIR}")
+message("  TEST_EXECUTABLE (executable tested)                         : ${TEST_EXECUTABLE}")
+message("  TEST_EXECUTABLE_ARGS (executable arguments)                 : ${TEST_EXECUTABLE_ARGS}")
+message("  TEST_LABELS (test labels)                                   : ${TEST_LABELS}")
+
+set(test_command ${TEST_EXECUTABLE} ${TEST_EXECUTABLE_ARGS})
+
+
+string(REPLACE ";" " " test_command_string "${test_command}")
+
+# Run the test
+message("\nRunning test command: '${test_command_string}'\n")
+execute_process(COMMAND ${test_command} RESULT_VARIABLE ERROR)
+
+# Check return value from test
+if(ERROR)
+
+  message(FATAL_ERROR "Test failed to run: '${test_command_string}' returned error code: ${ERROR}")
+
+else() # Test command ran successfully, do something extra after test run
+
+  # ...
+
+endif()


### PR DESCRIPTION
This customizes the cmake add_test and test runner functionality. Intended as an example, enabling further customization.

Also adds a couple of tests exercising some of the extra features added: _pass_regexp_ and _fail_regexp_.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Leenkh3/Firefly/19)
<!-- Reviewable:end -->
