### PR TITLE
Add Laplace operator and tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,23 +16,32 @@ add_library(MatrixLib
     src/matrix/Dense.h
 )
 
+# Configure a CSR matrix class
+add_library(CSR src/laplacian/CSR.cpp)
+# Configure a functions needed to compute the Laplacian
+add_library(Laplacian src/laplacian/Laplacian.cpp)
+
+# Configure building the executable to test the Laplacian
+add_executable(LaplacianTests src/laplacian/testLaplacian.cpp)
+target_link_libraries(LaplacianTests PRIVATE CSR Laplacian)
+
 
 add_executable(firefly firefly.cpp)
 
-# Configure the link command
-
-# target_link_libraries(firefly PRIVATE GmshMeshReader)
 # Configure cmake's testing system
 enable_testing()
 
 add_executable(MatrixTests src/matrix/test_matrix.cpp)
 # Link the Matrix library to the main executable
 target_link_libraries(MatrixTests PRIVATE MatrixLib)
+
 # Add a test, running the chillax executable, non-zero exit code will fail the test
 add_test(NAME firefly COMMAND firefly)
 
 # Add a test for the Matrix library
 add_test(NAME MatrixTests COMMAND MatrixTests)
+# Add tests for the Laplacian
+add_test(NAME laplacian COMMAND LaplacianTests)
 
 # Include function used to add regression tests
 include(add_regression_test)

--- a/src/laplacian/CSR.cpp
+++ b/src/laplacian/CSR.cpp
@@ -17,7 +17,6 @@ try :
 // *****************************************************************************
 //  Constructor: Create a CSR symmetric matrix with 1 scalar component per
 //  non-zero matrix entry, storing only the upper triangular part
-//! \param[in] nc Number of scalar components (degrees of freedom)
 //! \param[in] psup Points surrounding points of mesh graph, see tk::genPsup
 // *****************************************************************************
 {

--- a/src/laplacian/CSR.cpp
+++ b/src/laplacian/CSR.cpp
@@ -79,9 +79,9 @@ CSR::operator()( std::size_t row, std::size_t col ) const
 //! \return Const reference to matrix entry
 // *****************************************************************************
 {
-  for (std::size_t n=0, j=ia[row]-1; j<ia[row+1]-1; ++j, ++n)
+  for (std::size_t j=ia[row]-1; j<ia[row+1]-1; ++j)
     if (col+1 == ja[j])
-      return a[ia[row]-1+n];
+      return a[j];
 
   std::cerr << "Sparse matrix index not found";
   throw;

--- a/src/laplacian/CSR.cpp
+++ b/src/laplacian/CSR.cpp
@@ -1,0 +1,248 @@
+// *****************************************************************************
+/*!
+  \file      src/laplacian/CSR.cpp
+  \brief     Compressed sparse row (CSR) storage for a sparse matrix
+*/
+// *****************************************************************************
+
+#include <cassert>
+
+#include "CSR.hpp"
+
+CSR::CSR( const std::pair< std::vector< std::size_t >,
+                           std::vector< std::size_t > >& psup )
+try :
+  rnz( psup.second.size()-1 ),
+  ia( rnz.size()+1 )
+// *****************************************************************************
+//  Constructor: Create a CSR symmetric matrix with 1 scalar component per
+//  non-zero matrix entry, storing only the upper triangular part
+//! \param[in] nc Number of scalar components (degrees of freedom)
+//! \param[in] psup Points surrounding points of mesh graph, see tk::genPsup
+// *****************************************************************************
+{
+  assert( rnz.size() > 0 ); // Sparse matrix size must be positive
+
+  const auto& psup1 = psup.first;
+  const auto& psup2 = psup.second;
+
+  // Calculate number of nonzeros in each block row (rnz), total number of
+  // nonzeros (nnz), and fill in row indices (ia)
+  std::size_t nnz, i;
+  for (ia[0]=1, nnz=i=0; i<psup2.size()-1; ++i) {
+    // add up and store nonzeros of row i (only upper triangular part)
+    std::size_t j;
+    for (rnz[i]=1, j=psup2[i]+1; j<=psup2[i+1]; ++j)
+      ++rnz[i];
+
+    // add up total number of nonzeros
+    nnz += rnz[i];
+
+    // fill up row index
+    ia[i+1] = ia[i] + rnz[i];
+  }
+
+  // Allocate storage for matrix values and column indices
+  a.resize( nnz, 0.0 );
+  ja.resize( nnz );
+
+  // fill column indices
+  for (i=0; i<rnz.size(); ++i) {
+    auto itmp = i;
+    ja[ia[itmp]-1] = itmp+1;  // put in column index of diagonal
+    for (std::size_t n=1, j=psup2[i]+1; j<=psup2[i+1]; ++j) {
+      // put in column index of an off-diagonal
+      ja[ia[itmp]-1+(n++)] = psup1[j]+1;
+    }
+  }
+
+  // (bubble-)sort column indices
+  for (i=0; i<rnz.size(); ++i)
+    for (std::size_t j=psup2[i]+1; j<=psup2[i+1]; ++j)
+       for (std::size_t l=1; l<rnz[i]; ++l)   // sort column indices of row i
+          for (std::size_t e=0; e<rnz[i]-l; ++e)
+            if (ja[ia[i]-1+e] > ja[ia[i]+e])
+              std::swap( ja[ia[i]-1+e], ja[ia[i]+e] );
+
+} // Catch std::exception
+  catch (std::exception& se) {
+    // (re-)throw tk::Excpetion
+    std::cerr << std::string("RUNTIME ERROR in CSR constructor: ") + se.what();
+    throw;
+  }
+
+const double&
+CSR::operator()( std::size_t row, std::size_t col ) const
+// *****************************************************************************
+//  Return const reference to sparse matrix entry
+//! \param[in] row Block row
+//! \param[in] col Block column
+//! \return Const reference to matrix entry
+// *****************************************************************************
+{
+  for (std::size_t n=0, j=ia[row]-1; j<ia[row+1]-1; ++j, ++n)
+    if (col+1 == ja[j])
+      return a[ia[row]-1+n];
+
+  std::cerr << "Sparse matrix index not found";
+  throw;
+}
+
+void
+CSR::dirichlet( std::size_t i, double val, std::vector< double >& b )
+// *****************************************************************************
+//  Set Dirichlet boundary condition at a node
+//! \param[in] i Local id at which to set Dirichlet BC
+//! \param[in] val Value of Dirichlet BC
+//! \param[in,out] b RHS to modify as a result of setting the Dirichlet BC
+// *****************************************************************************
+{
+  // apply Dirichlet BC on rhs, zero column
+  for (std::size_t r=0; r<rnz.size(); ++r) {
+    for (std::size_t j=ia[r]-1; j<ia[r+1]-1; ++j) {
+      if (i+1 == ja[j]) {
+        b[r] += a[j] * val;
+        a[j] = 0.0;
+        break;
+      }
+    }
+  }
+
+  // zero row and put in diagonal
+  for (std::size_t j=ia[i]-1; j<ia[i+1]-1; ++j) {
+    if (i+1 == ja[j]) a[j] = 1.0; else a[j] = 0.0;
+  }
+}
+
+void
+CSR::mult( const std::vector< double >& x, std::vector< double >& r ) const
+// *****************************************************************************
+//  Multiply CSR matrix with vector from the right: r = A * x
+//! \param[in] x Vector to multiply matrix with from the right
+//! \param[in] r Result vector of product r = A * x
+//! \note This is only complete in serial. In parallel, this computes the own
+//!   contributions to the product, so it must be followed by communication
+//!   summing the products of rows stored on multiple partitions.
+// *****************************************************************************
+{
+  std::fill( begin(r), end(r), 0.0 );
+
+  for (std::size_t i=0; i<rnz.size(); ++i) {
+    for (std::size_t j=ia[i]-1; j<ia[i+1]-1; ++j) {
+      r[i] += a[j] * x[ja[j]-1];
+    }
+  }
+}
+
+void
+CSR::zero()
+// *****************************************************************************
+//  Zero matrix values
+// *****************************************************************************
+{
+  std::fill( begin(a), end(a), 0.0 );
+}
+
+std::ostream&
+CSR::write_stored( std::ostream& os ) const
+// *****************************************************************************
+//  Write out CSR as stored
+//! \param[in,out] os Output stream to write to
+//! \return Updated output stream
+// *****************************************************************************
+{
+  os << "size (npoin) = " << rnz.size() << '\n';
+  os << "ncomp = 1\n";
+  os << "rsize (size) = " << rnz.size() << '\n';
+  os << "nnz = " << a.size() << '\n';
+
+  std::size_t i;
+
+  os << "rnz[npoin=" << rnz.size() << "] = { ";
+  for (i=0; i<rnz.size()-1; ++i) os << rnz[i] << ", ";
+  os << rnz[i] << " }\n";
+
+  os << "ia[rsize+1=" << rnz.size()+1 << "] = { ";
+  for (i=0; i<ia.size()-1; ++i) os << ia[i] << ", ";
+  os << ia[i] << " }\n";
+
+  os << "ja[nnz=" << ja.size() << "] = { ";
+  for (i=0; i<ja.size()-1; ++i) os << ja[i] << ", ";
+  os << ja[i] << " }\n";
+
+  os << "a[nnz=" << a.size() << "] = { ";
+  for (i=0; i<a.size()-1; ++i) os << a[i] << ", ";
+  os << a[i] << " }\n";
+
+  return os;
+}
+
+std::ostream&
+CSR::write_structure( std::ostream& os ) const
+// *****************************************************************************
+//  Write out CSR nonzero structure
+//! \param[in,out] os Output stream to write to
+//! \return Updated output stream
+// *****************************************************************************
+{
+  for (std::size_t i=0; i<rnz.size(); ++i) {
+    // leading zeros
+    for (std::size_t j=1; j<ja[ia[i]-1]; ++j) os << ". ";
+    for (std::size_t n=ia[i]-1; n<ia[i+1]-1; ++n) {
+      // zeros between nonzeros
+      if (n>ia[i]-1) for (std::size_t j=ja[n-1]; j<ja[n]-1; ++j) os << ". ";
+      // nonzero
+      os << "o ";
+    }
+    // trailing zeros
+    for (std::size_t j=ja[ia[i+1]-2]; j<rnz.size(); ++j) os << ". ";
+    os << '\n';
+  }
+
+  return os;
+}
+
+std::ostream&
+CSR::write_matrix( std::ostream& os ) const
+// *****************************************************************************
+//  Write out CSR as a real matrix
+//! \param[in,out] os Output stream to write to
+//! \return Updated output stream
+// *****************************************************************************
+{
+  for (std::size_t i=0; i<rnz.size(); ++i) {
+    for (std::size_t j=1; j<ja[ia[i]-1]; ++j) os << "0\t";
+    for (std::size_t n=ia[i]-1; n<ia[i+1]-1; ++n) {
+      if (n>ia[i]-1) for (std::size_t j=ja[n-1]; j<ja[n]-1; ++j ) os << "0\t";
+      os << a[n] << '\t';
+    }
+    for (std::size_t j=ja[ia[i+1]-2]; j<rnz.size(); ++j) os << "0\t";
+    os << '\n';
+  }
+
+  return os;
+}
+
+std::ostream&
+CSR::write_matlab( std::ostream& os ) const
+// *****************************************************************************
+//  Write out CSR in Matlab/Octave format
+//! \param[in,out] os Output stream to write to
+//! \return Updated output stream
+// *****************************************************************************
+{
+  os << "A = [ ";
+  for (std::size_t i=0; i<rnz.size(); ++i) {
+    for (std::size_t j=1; j<ja[ia[i]-1]; ++j) os << "0 ";
+    for ( std::size_t n=ia[i]-1; n<ia[i+1]-1; ++n) {
+      if (n > ia[i]-1)
+        for (std::size_t j=ja[n-1]; j<ja[n]-1; ++j) os << "0 ";
+      os << a[n] << ' ';
+    }
+    for (std::size_t j=ja[ia[i+1]-2]; j<rnz.size(); ++j) os << "0 ";
+    os << ";\n";
+  }
+  os << "]\n";
+
+  return os;
+}

--- a/src/laplacian/CSR.hpp
+++ b/src/laplacian/CSR.hpp
@@ -1,0 +1,64 @@
+// *****************************************************************************
+/*!
+  \file      src/laplacian/CSR.hpp
+  \brief     Compressed sparse row (CSR) storage for a sparse matrix
+*/
+// *****************************************************************************
+#pragma once
+
+#include <iostream>
+#include <vector>
+
+//! Compressed sparse row (CSR) storage for a sparse matrix
+class CSR {
+
+  public:
+    //! \brief Constructor: Create a CSR symmetric matrix with one scalar
+    //!   component, storing only the upper triangular part
+    explicit CSR( const std::pair< std::vector< std::size_t >,
+                                   std::vector< std::size_t > >& psup );
+
+    //! Return const reference to sparse matrix entry
+    const double&
+    operator()( std::size_t row, std::size_t col ) const;
+
+    //! Return non-const reference to sparse matrix entry at a position
+    //! \see "Avoid Duplication in const and Non-const Member Function," and
+    //!   "Use const whenever possible," Scott Meyers, Effective C++, 3d ed.
+    double&
+    operator()( std::size_t row, std::size_t col ) {
+      return const_cast< double& >(
+               static_cast< const CSR& >( *this ).operator()( row, col ) );
+    }
+
+    //! Set Dirichlet boundary condition at a node
+    void dirichlet( std::size_t i,
+                    double val,
+                    std::vector< double >& b );
+
+    //! Multiply CSR matrix with vector from the right: r = A * x
+    void mult( const std::vector< double >& x, std::vector< double >& r ) const;
+
+    //! Zero matrix values
+    void zero();
+
+    //! Access real size of matrix
+    std::size_t rsize() const { return rnz.size(); }
+
+    //! Write out CSR as stored
+    std::ostream& write_stored( std::ostream &os ) const;
+    //! Write out CSR nonzero structure
+    std::ostream& write_structure( std::ostream &os ) const;
+    //! Write out CSR contribute structure
+    std::ostream& write_contribute( std::ostream &os ) const;
+    //! Write out CSR as a real matrix
+    std::ostream& write_matrix( std::ostream &os ) const;
+    //! Write out CSR in Matlab/Octave format
+    std::ostream& write_matlab( std::ostream &os ) const;
+
+  private:
+    std::vector< std::size_t > rnz;     //!< Number of nonzeros in each row
+    std::vector< std::size_t > ia;      //!< Row pointers
+    std::vector< std::size_t > ja;      //!< Column indices
+    std::vector< double > a;            //!< Nonzero matrix values
+};

--- a/src/laplacian/Laplacian.cpp
+++ b/src/laplacian/Laplacian.cpp
@@ -1,0 +1,306 @@
+// *****************************************************************************
+/*!
+  \file      src/Laplacian.hpp
+  \brief     Functionality to compute the Laplacian operator
+*/
+// *****************************************************************************
+
+#include <tuple>
+#include <cassert>
+#include <algorithm>
+
+#include "Laplacian.hpp"
+
+std::pair< std::vector< std::size_t >, std::vector< std::size_t > >
+genEsup( const std::vector< std::size_t >& inpoel, std::size_t nnpe )
+// *****************************************************************************
+//  Generate derived data structure, elements surrounding points
+//! \param[in] inpoel Inteconnectivity of points and elements. These are the
+//!   node ids of each element of an unstructured mesh. Example:
+//!   \code{.cpp}
+//!     std::vector< std::size_t > inpoel { 12, 14,  9, 11,
+//!                                         10, 14, 13, 12 };
+//!   \endcode
+//!   specifies two tetrahedra whose vertices (node ids) are { 12, 14, 9, 11 },
+//!   and { 10, 14, 13, 12 }.
+//! \param[in] nnpe Number of nodes per element
+//! \return Linked lists storing elements surrounding points
+//! \warning It is not okay to call this function with an empty container or a
+//!   non-positive number of nodes per element; it will throw an exception.
+//! \details The data generated here is stored in a linked list, more precisely,
+//!   two linked arrays (vectors), _esup1_ and _esup2_, where _esup2_ holds the
+//!   indices at which _esup1_ holds the element ids surrounding points. Looping
+//!   over all elements surrounding all points can then be accomplished by the
+//!   following loop:
+//!   \code{.cpp}
+//!     for (std::size_t p=0; p<npoin; ++p)
+//!       for (auto i=esup.second[p]+1; i<=esup.second[p+1]; ++i)
+//!          use element id esup.first[i]
+//!   \endcode
+//!     To find out the number of points, _npoin_, the mesh connectivity,
+//!     _inpoel_, can be queried:
+//!   \code{.cpp}
+//!     auto minmax = std::minmax_element( begin(inpoel), end(inpoel) );
+//!     assert( *minmax.first == 0); // node ids should start from zero
+//!     auto npoin = *minmax.second + 1;
+//!   \endcode
+//! \note In principle, this function *should* work for any positive nnpe,
+//!   however, only nnpe = 4 (tetrahedra) and nnpe = 3 (triangles) are tested.
+//! \see Lohner, An Introduction to Applied CFD Techniques, Wiley, 2008
+// *****************************************************************************
+{
+  assert( !inpoel.empty() ); // Attempt to call genEsup() on empty container
+  assert( nnpe > 0 ); // Attempt to call genEsup() with zero nodes per element
+  assert( inpoel.size()%nnpe == 0 ); // Size of inpoel must be divisible by nnpe
+
+  // find out number of points in mesh connectivity
+  auto minmax = std::minmax_element( begin(inpoel), end(inpoel) );
+  assert( *minmax.first == 0 ); // node ids should start from zero
+  auto npoin = *minmax.second + 1;
+
+  // allocate one of the linked lists storing elements surrounding points: esup2
+  // fill with zeros
+  std::vector< std::size_t > esup2( npoin+1, 0 );
+
+  // element pass 1: count number of elements connected to each point
+  for (auto n : inpoel) ++esup2[ n + 1 ];
+
+  // storage/reshuffling pass 1: update storage counter and store
+  // also find out the maximum size of esup1 (mesup)
+  auto mesup = esup2[0]+1;
+  for (std::size_t i=1; i<npoin+1; ++i) {
+    esup2[i] += esup2[i-1];
+    if (esup2[i]+1 > mesup) mesup = esup2[i]+1;
+  }
+
+  // now we know mesup, so allocate the other one of the linked lists storing
+  // elements surrounding points: esup1
+  std::vector< std::size_t > esup1( mesup );
+
+  // store the elements in esup1
+  std::size_t e = 0;
+  for (auto n : inpoel) {
+    auto j = esup2[n]+1;
+    esup2[n] = j;
+    esup1[j] = e/nnpe;
+    ++e;
+  }
+
+  // storage/reshuffling pass 2
+  for (auto i=npoin; i>0; --i) esup2[i] = esup2[i-1];
+  esup2[0] = 0;
+
+  // Return (move out) linked lists
+  return std::make_pair( std::move(esup1), std::move(esup2) );
+}
+
+std::pair< std::vector< std::size_t >, std::vector< std::size_t > >
+genPsup( const std::vector< std::size_t >& inpoel,
+         std::size_t nnpe,
+         const std::pair< std::vector< std::size_t >,
+                          std::vector< std::size_t > >& esup )
+// *****************************************************************************
+//  Generate derived data structure, points surrounding points
+//! \param[in] inpoel Inteconnectivity of points and elements. These are the
+//!   node ids of each element of an unstructured mesh. Example:
+//!   \code{.cpp}
+//!     std::vector< std::size_t > inpoel { 12, 14,  9, 11,
+//!                                         10, 14, 13, 12 };
+//!   \endcode
+//!   specifies two tetrahedra whose vertices (node ids) are { 12, 14, 9, 11 },
+//!   and { 10, 14, 13, 12 }.
+//! \param[in] nnpe Number of nodes per element
+//! \param[in] esup Elements surrounding points as linked lists, see tk::genEsup
+//! \return Linked lists storing points surrounding points
+//! \warning It is not okay to call this function with an empty container for
+//!   inpoel or esup.first or esup.second or a non-positive number of nodes per
+//!   element; it will throw an exception.
+//! \details The data generated here is stored in a linked list, more precisely,
+//!   two linked arrays (vectors), _psup1_ and _psup2_, where _psup2_ holds the
+//!   indices at which _psup1_ holds the point ids surrounding points. Looping
+//!   over all points surrounding all points can then be accomplished by the
+//!   following loop:
+//!   \code{.cpp}
+//!     for (std::size_t p=0; p<npoin; ++p)
+//!       for (auto i=psup.second[p]+1; i<=psup.second[p+1]; ++i)
+//!          use point id psup.first[i]
+//!   \endcode
+//!    To find out the number of points, _npoin_, the mesh connectivity,
+//!    _inpoel_, can be queried:
+//!   \code{.cpp}
+//!     auto minmax = std::minmax_element( begin(inpoel), end(inpoel) );
+//!     assert( *minmax.first == 0 ); // node ids should start from zero
+//!     auto npoin = *minmax.second + 1;
+//!   \endcode
+//!   or the length-1 of the generated index list:
+//!   \code{.cpp}
+//!     auto npoin = psup.second.size()-1;
+//!   \endcode
+//! \note In principle, this function *should* work for any positive nnpe,
+//!   however, only nnpe = 4 (tetrahedra) and nnpe = 3 (triangles) are tested.
+//! \see Lohner, An Introduction to Applied CFD Techniques, Wiley, 2008
+// *****************************************************************************
+{
+  assert( !inpoel.empty() ); // Attempt to call genPsup() on empty container
+  assert( nnpe > 0 ); // Attempt to call genPsup() with zero nodes per element
+  assert( inpoel.size()%nnpe == 0 ); // Size of inpoel must be divisible by nnpe
+  assert( !esup.first.empty() ); // Attempt to call genPsup() with empty esup1
+  assert( !esup.second.empty() ); // Attempt to call genPsup() with empty esup2
+
+  // find out number of points in mesh connectivity
+  auto minmax = std::minmax_element( begin(inpoel), end(inpoel) );
+  assert( *minmax.first == 0 ); // node ids should start from zero
+  auto npoin = *minmax.second + 1;
+
+  auto& esup1 = esup.first;
+  auto& esup2 = esup.second;
+
+  // allocate both of the linked lists storing points surrounding points, we
+  // only know the size of psup2, put in a single zero in psup1
+  std::vector< std::size_t > psup2( npoin+1 ), psup1( 1, 0 );
+
+  // allocate and fill with zeros a temporary array, only used locally
+  std::vector< std::size_t > lpoin( npoin, 0 );
+
+  // fill both psup1 and psup2
+  psup2[0] = 0;
+  std::size_t j = 0;
+  for (std::size_t p=0; p<npoin; ++p) {
+    for (std::size_t i=esup2[p]+1; i<=esup2[p+1]; ++i ) {
+      for (std::size_t n=0; n<nnpe; ++n) {
+        auto q = inpoel[ esup1[i] * nnpe + n ];
+        if (q != p && lpoin[q] != p+1) {
+          ++j;
+          psup1.push_back( q );
+          lpoin[q] = p+1;
+        }
+      }
+    }
+    psup2[p+1] = j;
+  }
+
+  // sort point ids for each point in psup1
+  for (std::size_t p=0; p<npoin; ++p)
+    std::sort(
+      std::next( begin(psup1), static_cast<std::ptrdiff_t>(psup2[p]+1) ),
+      std::next( begin(psup1), static_cast<std::ptrdiff_t>(psup2[p+1]+1) ) );
+
+  // Return (move out) linked lists
+  return std::make_pair( std::move(psup1), std::move(psup2) );
+}
+
+//! Compute the cross-product of two vectors divided by a scalar
+//! \param[in] v1 1st vector
+//! \param[in] v2 2nd vector
+//! \param[in] j Scalar to divide each component by
+//! \return Cross-product divided by scalar
+inline std::array< double, 3 >
+crossdiv( const std::array< double, 3 >& v1,
+          const std::array< double, 3 >& v2,
+          double j )
+{
+  return {{ (v1[1]*v2[2] - v2[1]*v1[2]) / j,
+            (v1[2]*v2[0] - v2[2]*v1[0]) / j,
+            (v1[0]*v2[1] - v2[0]*v1[1]) / j }};
+}
+
+//! Compute the dot-product of two vectors
+//! \param[in] v1 1st vector
+//! \param[in] v2 2nd vector
+//! \return Dot-product
+inline double
+dot( const std::array< double, 3 >& v1, const std::array< double, 3 >& v2 ) {
+  return v1[0]*v2[0] + v1[1]*v2[1] + v1[2]*v2[2];
+}
+
+//! Compute the cross-product of two vectors
+//! \param[in] v1x x coordinate of the 1st vector
+//! \param[in] v1y y coordinate of the 1st vector
+//! \param[in] v1z z coordinate of the 1st vector
+//! \param[in] v2x x coordinate of the 2nd vector
+//! \param[in] v2y y coordinate of the 2nd vector
+//! \param[in] v2z z coordinate of the 2nd vector
+//! \param[out] rx x coordinate of the product vector
+//! \param[out] ry y coordinate of the product vector
+//! \param[out] rz z coordinate of the product vector
+inline void
+cross( double v1x, double v1y, double v1z,
+       double v2x, double v2y, double v2z,
+       double& rx, double& ry, double& rz )
+{
+  rx = v1y*v2z - v2y*v1z;
+  ry = v1z*v2x - v2z*v1x;
+  rz = v1x*v2y - v2x*v1y;
+}
+
+//! Compute the cross-product of two vectors
+//! \param[in] v1 1st vector
+//! \param[in] v2 2nd vector
+//! \return Cross-product
+inline std::array< double, 3 >
+cross( const std::array< double, 3 >& v1, const std::array< double, 3 >& v2 ) {
+  double rx, ry, rz;
+  cross( v1[0], v1[1], v1[2], v2[0], v2[1], v2[2], rx, ry, rz );
+  return { std::move(rx), std::move(ry), std::move(rz) };
+}
+
+//! Compute the triple-product of three vectors
+//! \param[in] v1 1st vector
+//! \param[in] v2 2nd vector
+//! \param[in] v3 3rd vector
+//! \return Triple-product
+inline double
+triple( const std::array< double, 3 >& v1,
+        const std::array< double, 3 >& v2,
+        const std::array< double, 3 >& v3 )
+{
+  return dot( v1, cross(v2,v3) );
+}
+
+std::tuple< CSR, std::vector< double >, std::vector< double > >
+laplacian( const std::vector< std::size_t >& inpoel,
+           const std::array< std::vector< double >, 3 >& coord )
+// *****************************************************************************
+//  Setup matrix with Laplacian
+//! \param[in] inpoel Mesh node connectivity
+//! \param[in] coord Mesh node coordinates
+//! \param[in] psup Points surrounding points
+//! \return { A, x, b } in linear system A * x = b to solve
+// *****************************************************************************
+{
+  const auto& X = coord[0];
+  const auto& Y = coord[1];
+  const auto& Z = coord[2];
+
+  // compute points surrounding points
+  auto psup = genPsup( inpoel, 4, genEsup(inpoel,4) );
+
+  // Matrix with compressed sparse row storage
+  CSR A( psup );
+
+  // fill matrix with Laplacian
+  for (std::size_t e=0; e<inpoel.size()/4; ++e) {
+    const auto N = inpoel.data() + e*4;
+    const std::array< double, 3 >
+      ba{{ X[N[1]]-X[N[0]], Y[N[1]]-Y[N[0]], Z[N[1]]-Z[N[0]] }},
+      ca{{ X[N[2]]-X[N[0]], Y[N[2]]-Y[N[0]], Z[N[2]]-Z[N[0]] }},
+      da{{ X[N[3]]-X[N[0]], Y[N[3]]-Y[N[0]], Z[N[3]]-Z[N[0]] }};
+    const auto J = triple( ba, ca, da );        // J = 6V
+    assert( J > 0 ); // Element Jacobian non-positive
+    std::array< std::array< double, 3 >, 4 > grad;
+    grad[1] = crossdiv( ca, da, J );
+    grad[2] = crossdiv( da, ba, J );
+    grad[3] = crossdiv( ba, ca, J );
+    for (std::size_t i=0; i<3; ++i)
+      grad[0][i] = -grad[1][i]-grad[2][i]-grad[3][i];
+    for (std::size_t a=0; a<4; ++a)
+      for (std::size_t b=0; b<4; ++b)
+         for (std::size_t k=0; k<3; ++k)
+           A(N[a],N[b]) -= J/6.0 * grad[a][k] * grad[b][k];
+  }
+
+  auto nunk = X.size();
+  std::vector< double > x( nunk, 0.0 ), b( nunk, 0.0 );
+
+  return { std::move(A), std::move(x), std::move(b) };
+}

--- a/src/laplacian/Laplacian.hpp
+++ b/src/laplacian/Laplacian.hpp
@@ -1,0 +1,29 @@
+// *****************************************************************************
+/*!
+  \file      src/laplacian/Laplacian.hpp
+  \brief     Functionality to compute the Laplacian operator
+*/
+// *****************************************************************************
+#pragma once
+
+#include <tuple>
+#include <array>
+#include <vector>
+
+#include "CSR.hpp"
+
+//! Generate derived data structure, elements surrounding points
+std::pair< std::vector< std::size_t >, std::vector< std::size_t > >
+genEsup( const std::vector< std::size_t >& inpoel, std::size_t nnpe );
+
+//! Generate derived data structure, points surrounding points
+std::pair< std::vector< std::size_t >, std::vector< std::size_t > >
+genPsup( const std::vector< std::size_t >& inpoel,
+         std::size_t nnpe,
+         const std::pair< std::vector< std::size_t >,
+                          std::vector< std::size_t > >& esup );
+
+//  Setup matrix with Laplacian
+std::tuple< CSR, std::vector< double >, std::vector< double > >
+laplacian( const std::vector< std::size_t >& inpoel,
+           const std::array< std::vector< double >, 3 >& coord );

--- a/src/laplacian/testLaplacian.cpp
+++ b/src/laplacian/testLaplacian.cpp
@@ -1,0 +1,193 @@
+// *****************************************************************************
+/*!
+  \file      src/laplacian/testLaplacian.cpp
+  \brief     Generate and test a Laplacian operator
+*/
+// *****************************************************************************
+
+#include <cstddef>
+#include <vector>
+#include <iostream>
+#include <algorithm>
+#include <sstream>
+
+#include "../laplacian/Laplacian.hpp"
+
+std::size_t
+shiftToZero( std::vector< std::size_t >& inpoel )
+// *****************************************************************************
+//  Shift node IDs to start with zero in element connectivity
+//! \param[inout] inpoel Inteconnectivity of points and elements
+//! \return Amount shifted
+//! \details This function implements a simple reordering of the node ids of the
+//!   element connectivity in inpoel by shifting the node ids so that the
+//!   smallest is zero.
+//! \note It is okay to call this function with an empty container; it will
+//!    simply return without throwing an exception.
+// *****************************************************************************
+{
+  if (inpoel.empty()) return 0;
+
+  // find smallest node id
+  auto minId = *std::min_element( begin(inpoel), end(inpoel) );
+
+  // shift node ids to start from zero
+  for (auto& n : inpoel) n -= minId;
+
+  return minId;
+}
+
+int
+testCSR()
+// *****************************************************************************
+// Test CSR matrix storage
+// *****************************************************************************
+{
+  // Mesh connectivity for simple tetrahedron-only mesh
+  std::vector< std::size_t > inpoel { 12, 14,  9, 11,
+                                      10, 14, 13, 12,
+                                      14, 13, 12,  9,
+                                      10, 14, 12, 11,
+                                      1,  14,  5, 11,
+                                      7,   6, 10, 12,
+                                      14,  8,  5, 10,
+                                      8,   7, 10, 13,
+                                      7,  13,  3, 12,
+                                      1,   4, 14,  9,
+                                      13,  4,  3,  9,
+                                      3,   2, 12,  9,
+                                      4,   8, 14, 13,
+                                      6,   5, 10, 11,
+                                      1,   2,  9, 11,
+                                      2,   6, 12, 11,
+                                      6,  10, 12, 11,
+                                      2,  12,  9, 11,
+                                      5,  14, 10, 11,
+                                      14,  8, 10, 13,
+                                      13,  3, 12,  9,
+                                      7,  10, 13, 12,
+                                      14,  4, 13,  9,
+                                      14,  1,  9, 11 };
+
+  // Mesh node coordinates for simple tet mesh above
+  std::array< std::vector< double >, 3 > coord {{
+    {{ 0, 1, 1, 0, 0, 1, 1, 0, 0.5, 0.5, 0.5, 1,   0.5, 0 }},
+    {{ 0, 0, 1, 1, 0, 0, 1, 1, 0.5, 0.5, 0,   0.5, 1,   0.5 }},
+    {{ 0, 0, 0, 0, 1, 1, 1, 1, 0,   1,   0.5, 0.5, 0.5, 0.5 }} }};
+
+  // Shift node IDs to start from zero
+  shiftToZero( inpoel );
+
+  // Generate points surrounding points
+  auto psup = genPsup( inpoel, 4, genEsup(inpoel,4) );
+
+  // Create matrix
+  CSR c( psup );
+
+  // Output sparse matrix data to stringstream
+  std::stringstream ss;
+  c.write_stored( ss );
+
+  auto correct = R"(size (npoin) = 14
+ncomp = 1
+rsize (size) = 14
+nnz = 112
+rnz[npoin=14] = { 7, 7, 7, 7, 7, 7, 7, 7, 9, 9, 9, 10, 9, 10 }
+ia[rsize+1=15] = { 1, 8, 15, 22, 29, 36, 43, 50, 57, 66, 75, 84, 94, 103, 113 }
+ja[nnz=112] = { 1, 2, 4, 5, 9, 11, 14, 1, 2, 3, 6, 9, 11, 12, 2, 3, 4, 7, 9, 12, 13, 1, 3, 4, 8, 9, 13, 14, 1, 5, 6, 8, 10, 11, 14, 2, 5, 6, 7, 10, 11, 12, 3, 6, 7, 8, 10, 12, 13, 4, 5, 7, 8, 10, 13, 14, 1, 2, 3, 4, 9, 11, 12, 13, 14, 5, 6, 7, 8, 10, 11, 12, 13, 14, 1, 2, 5, 6, 9, 10, 11, 12, 14, 2, 3, 6, 7, 9, 10, 11, 12, 13, 14, 3, 4, 7, 8, 9, 10, 12, 13, 14, 1, 4, 5, 8, 9, 10, 11, 12, 13, 14 }
+a[nnz=112] = { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 }
+)";
+
+  // test CSR matrix data
+  if (ss.str() != correct ) {
+    std::cerr << "CSR write_stored incorrect";
+    return -1;
+  }
+
+  return 0;
+}
+
+int
+testLaplacian()
+// *****************************************************************************
+// Test Laplace operator
+// *****************************************************************************
+{
+  // Mesh connectivity for simple tetrahedron-only mesh
+  std::vector< std::size_t > inpoel {
+    3, 13, 8, 14,
+    12, 3, 13, 8,
+    8, 3, 14, 11,
+    12, 3, 8, 11,
+    1, 2, 3, 13,
+    6, 13, 7, 8,
+    5, 9, 14, 11,
+    5, 1, 3, 14,
+    10, 4, 12, 11,
+    2, 6, 12, 13,
+    8, 7, 9, 14,
+    13, 1, 7, 14,
+    5, 3, 4, 11,
+    6, 10, 12, 8,
+    3, 2, 4, 12,
+    10, 8, 9, 11,
+    3, 1, 13, 14,
+    13, 7, 8, 14,
+    6, 12, 13, 8,
+    9, 8, 14, 11,
+    3, 5, 14, 11,
+    4, 3, 12, 11,
+    3, 2, 12, 13,
+    10, 12, 8, 11 };
+
+  // Mesh node coordinates for simple tet mesh above
+  std::array< std::vector< double >, 3 > coord {{
+    {{ -0.5, -0.5, -0.5, -0.5, -0.5, 0.5, 0.5, 0.5, 0.5, 0.5, 0, 0, 0, 0 }},
+    {{ 0.5, 0.5, 0, -0.5, -0.5, 0.5, 0.5, 0, -0.5, -0.5, -0.5, 0, 0.5, 0 }},
+    {{ -0.5, 0.5, 0, 0.5, -0.5, 0.5, -0.5, 0, -0.5, 0.5, 0, 0.5, 0, -0.5 }} }};
+
+  // Shift node IDs to start from zero
+  shiftToZero( inpoel );
+
+  // Fill matrix with Laplace operator values
+  auto [A,x,b] = laplacian( inpoel, coord );
+
+  // Output sparse matrix data to stringstream
+  std::stringstream ss;
+  A.write_matlab( ss );
+  //A.write_matlab( std::cout );
+
+  auto correct = R"(A = [ -0.5 -0.0416667 0.208333 0 -0.0416667 0 -0.0416667 0 0 0 0 0 0.208333 0.208333 ;
+-0.0416667 -0.5 0.208333 -0.0416667 0 -0.0416667 0 0 0 0 0 0.208333 0.208333 0 ;
+0.208333 0.208333 -1.66667 0.208333 0.208333 0 0 -0.166667 0 0 0.25 0.25 0.25 0.25 ;
+0 -0.0416667 0.208333 -0.5 -0.0416667 0 0 0 0 -0.0416667 0.208333 0.208333 0 0 ;
+-0.0416667 0 0.208333 -0.0416667 -0.5 0 0 0 -0.0416667 0 0.208333 0 0 0.208333 ;
+0 -0.0416667 0 0 0 -0.5 -0.0416667 0.208333 0 -0.0416667 0 0.208333 0.208333 0 ;
+-0.0416667 0 0 0 0 -0.0416667 -0.5 0.208333 -0.0416667 0 0 0 0.208333 0.208333 ;
+0 0 -0.166667 0 0 0.208333 0.208333 -1.66667 0.208333 0.208333 0.25 0.25 0.25 0.25 ;
+0 0 0 0 -0.0416667 0 -0.0416667 0.208333 -0.5 -0.0416667 0.208333 0 0 0.208333 ;
+0 0 0 -0.0416667 0 -0.0416667 0 0.208333 -0.0416667 -0.5 0.208333 0.208333 0 0 ;
+0 0 0.25 0.208333 0.208333 0 0 0.25 0.208333 0.208333 -1.5 0.0833333 0 0.0833333 ;
+0 0.208333 0.25 0.208333 0 0.208333 0 0.25 0 0.208333 0.0833333 -1.5 0.0833333 0 ;
+0.208333 0.208333 0.25 0 0 0.208333 0.208333 0.25 0 0 0 0.0833333 -1.5 0.0833333 ;
+0.208333 0 0.25 0 0.208333 0 0.208333 0.25 0.208333 0 0.0833333 0 0.0833333 -1.5 ;
+]
+)";
+
+  // test Laplace matrix data
+  if (ss.str() != correct ) {
+    std::cerr << "Laplace operator write_matlab incorrect";
+    return -1;
+  }
+
+  return 0;
+}
+
+int
+main(int argc, char * argv[])
+// *****************************************************************************
+// Test main
+// *****************************************************************************
+{
+  return testCSR() or testLaplacian();
+}


### PR DESCRIPTION
This adds functionality required to compute the values of a sparse matrix resulting from the finite element discretization of the Laplace operator on an unstructured tetrahedron mesh. 

@AliSaleemHasan, please note that I simply lifted in my version of the sparse matrix, feel free to replace this with yours once that's ready, until that this is good for testing and to see how the matrix values are generated. (You can also use the Laplace operator to generate test input for your matrix, similar to what I put in for the Laplace tests.)

@AliSaleemHasan, please also note the various member functions `CSR::write_*' useful for debugging and printing a sparse matrix to the screen.

Please see how the operators are coded in function `Laplacian()` at the bottom `Laplacian.cpp` with respect to the math at the end of the slides attached to the matrix room at https://matrix.to/#/!JpTNvEVFmQDryLVGuE:matrix.org/$r8TpfIHddlMdkpYU9-w5Krxz7dK3QaCcyxRyQqG089U

@danield0ma, @TheNomad456, please see examples of unit tests involving mesh connectivity.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Leenkh3/Firefly/24)
<!-- Reviewable:end -->
